### PR TITLE
Count p3scan clients

### DIFF
--- a/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/p3scan.rb
+++ b/root/opt/puppetlabs/puppet/lib/ruby/2.1.0/facter/p3scan.rb
@@ -1,0 +1,10 @@
+# p3scan_clients
+# Count the number of POP3 clients
+
+Facter.add('p3scan_clients') do
+    confine osfamily: 'RedHat'
+    setcode do
+        tmp = Facter::Core::Execution.exec('grep p3scan /var/log/messages | grep USER | awk \'{print $7}\' | sort | uniq | wc -l')
+        tmp.to_i
+    end
+end


### PR DESCRIPTION
Note on implementation: using grep on `/var/log/messages` is much faster then filtering `journalctl -u p3scan`